### PR TITLE
Ensured all columns appear in predictions file. Fixed a filename bug

### DIFF
--- a/jupyter_notebooks/devranker_Predictions.ipynb
+++ b/jupyter_notebooks/devranker_Predictions.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "# Use cuda - nvidia-smi if you have it installed\n",
     "# Add a flag with Default as False. Don't change this unless you have cuda installed.\n",
-    "nvidia_cuda = True"
+    "nvidia_cuda = False"
    ]
   },
   {
@@ -64,8 +64,8 @@
     "\n",
     "\n",
     "\n",
-    "    pred_ml_commits = pred_commits[['hash','Author_encrypted','Committer_encrypted','committed_date', \\\n",
-    "                                    'Email_encrypted', 'feature_total_changed',\n",
+    "    pred_ml_commits = pred_commits[['hash','Author_encrypted','Committer_encrypted','Email_encrypted','committed_date', \\\n",
+    "                                    'feature_total_changed',\n",
     "                                    'feature_add_del_functions', 'feature_changed_functions',\n",
     "                                    'feature_dmm_unit_complexity',\n",
     "                                    'feature_dmm_size','feature_dmm_unit_interfacing']]\n",
@@ -75,20 +75,12 @@
     "\n",
     "    # Author/text column needs to be dropped before converting the all the fields into numeric types\n",
     "    pred_ml_commits_na = pred_ml_commits.drop(columns = \\\n",
-    "                        ['Email_encrypted', 'Author_encrypted','hash','Committer_encrypted','committed_date'])\n",
+    "                        ['hash','Author_encrypted','Committer_encrypted','Email_encrypted','committed_date'])\n",
     "\n",
     "    # Converting the fields to numeric types, filling the NaNs with zeros\n",
     "    pred_ml_commits_numeric = pred_ml_commits_na.apply(pd.to_numeric,errors ='coerce').fillna(0)\n",
     "\n",
-    "    # Adding teh Author/text column back\n",
-    "    pred_ml_commits_all_coloumns = pred_ml_commits_numeric.copy()\n",
-    "    pred_ml_commits_all_coloumns['Author_encrypted'] = pred_ml_commits['Author_encrypted']\n",
-    "    pred_ml_commits_all_coloumns['hash'] = pred_ml_commits['hash']\n",
-    "    pred_ml_commits_all_coloumns['Committer_encrypted'] = pred_ml_commits['Committer_encrypted']\n",
-    "    pred_ml_commits_all_coloumns['committed_date'] = pred_ml_commits['committed_date']\n",
-    "    pred_ml_commits_all_coloumns['Email_encrypted'] = pred_ml_commits['Email_encrypted']\n",
-    "\n",
-    "    return pred_ml_commits_numeric, pred_ml_commits_all_coloumns"
+    "    return pred_ml_commits_numeric, pred_commits"
    ]
   },
   {
@@ -212,7 +204,7 @@
     "        target_repo_data_frame_all_coloumns['mod_score'] = target_repo_data_frame_all_coloumns['sum_centroid'] * target_repo_data_frame_all_coloumns['probablities']\n",
     "        \n",
     "        # Append these results to target_predictions file\n",
-    "        with open(predictions_folder+'scores_'+target_repo_raw_data_file, 'a') as predictions_file:\n",
+    "        with open(predictions_folder+'cpu_scores_'+target_repo_raw_data_file, 'a') as predictions_file:\n",
     "            target_repo_data_frame_all_coloumns.to_csv(predictions_file, mode='a', \\\n",
     "                                                       header=predictions_file.tell()==0)\n",
     "    else:\n",
@@ -407,13 +399,6 @@
     "            print('processing complete: ', store_end)\n",
     "            print('time taken: ', (store_end - store_start))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/jupyter_notebooks/devranker_getData.ipynb
+++ b/jupyter_notebooks/devranker_getData.ipynb
@@ -595,9 +595,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cuda_python_env",
+   "display_name": "14Jan21_cuda_python_env",
    "language": "python",
-   "name": "cuda_python_env"
+   "name": "14jan21_cuda_python_env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -609,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Ensured all columns appear in predictions file - Instead of creating a new 'pandas' to write out to file, changed this to simply retaining the original columns and adding the new columns to the pandas before writing out to file.
2.  'cpu' prediction was creating 2 files instead of just one. We were writing 'cpu' predictions to a different file.There was a bug where we did not name the files correctly. This has been fixed.